### PR TITLE
Fix CI workflow and AKS ingress compatibility

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,15 +16,18 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Build and test microservices
+        shell: bash
         run: |
           for dir in micro-services/*-service; do
-            mvn -f "$dir/pom.xml" -B test
+            mvn -f "$dir/pom.xml" -B -ntp test
           done
       - name: Package microservices
+        shell: bash
         run: |
           for dir in micro-services/*-service; do
-            mvn -f "$dir/pom.xml" -B package -DskipTests
+            mvn -f "$dir/pom.xml" -B -ntp package -DskipTests
           done
 
   terraform:

--- a/helm-charts/billing-service/templates/ingress.yaml
+++ b/helm-charts/billing-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "billing-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/client-service/templates/ingress.yaml
+++ b/helm-charts/client-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "client-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/gateway-service/templates/ingress.yaml
+++ b/helm-charts/gateway-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "gateway-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/matching-service/templates/ingress.yaml
+++ b/helm-charts/matching-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "matching-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/notification-service/templates/ingress.yaml
+++ b/helm-charts/notification-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "notification-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/provider-service/templates/ingress.yaml
+++ b/helm-charts/provider-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "provider-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/helm-charts/request-service/templates/ingress.yaml
+++ b/helm-charts/request-service/templates/ingress.yaml
@@ -3,10 +3,9 @@ kind: Ingress
 metadata:
   name: {{ include "request-service.fullname" . }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: alb
+  ingressClassName: nginx
   rules:
     - http:
         paths:

--- a/k8s/base/ingress-controller.yaml
+++ b/k8s/base/ingress-controller.yaml
@@ -2,5 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
 spec:
   controller: k8s.io/ingress-nginx


### PR DESCRIPTION
## Summary
- add Maven cache and quiet options to GitHub Actions workflow
- set default ingress class in base manifest
- update service ingress templates for AKS (Nginx)

## Testing
- `mvn -f micro-services/billing-service/pom.xml -q -ntp test` *(fails: Could not transfer artifact)*
- `terraform -chdir=terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888323dfc288328ae0d22239f50c5d4