### PR TITLE
Fix ingress host conflicts in Helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,24 @@ terraform -chdir=terraform validate
 
 ## CI/CD
 O workflow padrão em `.github/workflows/ci-cd.yml` executa build e testes de todos os microserviços e gera o plano do Terraform a cada `push` ou `pull_request` para a branch `main`.
+
+## Implantação com Helm e Kubernetes
+Após a criação do cluster, aplique os manifestos base e instale os charts de cada serviço:
+
+```bash
+# recursos de namespace e ingress controller
+kubectl apply -k k8s/base
+
+# instalar ou atualizar os serviços
+for svc in billing client gateway matching notification provider request; do
+  helm upgrade --install "${svc}-service" "./helm-charts/${svc}-service" \
+    --namespace freelas-dev \
+    --values "./k8s/overlays/dev/values-dev-${svc}-service.yaml"
+done
+```
+
+Ao final, confira os ingressos criados com:
+
+```bash
+kubectl get ingress -n freelas-dev
+```

--- a/helm-charts/billing-service/templates/ingress.yaml
+++ b/helm-charts/billing-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "billing-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "billing-service.fullname" . }}
+                name: {{ include "billing-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/billing-service/values.yaml
+++ b/helm-charts/billing-service/values.yaml
@@ -14,3 +14,15 @@ resources:
     cpu: 250m
     memory: 256Mi
 affinity: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: billing.freelas.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/client-service/templates/ingress.yaml
+++ b/helm-charts/client-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "client-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "client-service.fullname" . }}
+                name: {{ include "client-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/client-service/values.yaml
+++ b/helm-charts/client-service/values.yaml
@@ -21,3 +21,15 @@ env:
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: client.freelas.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/gateway-service/templates/ingress.yaml
+++ b/helm-charts/gateway-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "gateway-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "gateway-service.fullname" . }}
+                name: {{ include "gateway-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/gateway-service/values.yaml
+++ b/helm-charts/gateway-service/values.yaml
@@ -14,3 +14,15 @@ resources:
     cpu: 250m
     memory: 256Mi
 affinity: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: gateway.freelas.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/matching-service/templates/ingress.yaml
+++ b/helm-charts/matching-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "matching-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "matching-service.fullname" . }}
+                name: {{ include "matching-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/matching-service/values.yaml
+++ b/helm-charts/matching-service/values.yaml
@@ -14,3 +14,15 @@ resources:
     cpu: 250m
     memory: 256Mi
 affinity: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: matching.freelas.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/notification-service/templates/ingress.yaml
+++ b/helm-charts/notification-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "notification-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "notification-service.fullname" . }}
+                name: {{ include "notification-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/notification-service/values.yaml
+++ b/helm-charts/notification-service/values.yaml
@@ -14,3 +14,15 @@ resources:
     cpu: 250m
     memory: 256Mi
 affinity: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: notification.freelas.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/provider-service/templates/ingress.yaml
+++ b/helm-charts/provider-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "provider-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "provider-service.fullname" . }}
+                name: {{ include "provider-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/provider-service/values.yaml
+++ b/helm-charts/provider-service/values.yaml
@@ -21,3 +21,14 @@ env:
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: provider.freelas.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm-charts/request-service/templates/ingress.yaml
+++ b/helm-charts/request-service/templates/ingress.yaml
@@ -1,18 +1,33 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "request-service.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
-    - http:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "request-service.fullname" . }}
+                name: {{ include "request-service.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/request-service/values.yaml
+++ b/helm-charts/request-service/values.yaml
@@ -21,3 +21,14 @@ env:
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: request.freelas.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []


### PR DESCRIPTION
## Summary
- define ingress configuration in chart values
- template ingress resources using configured hosts
- document helm deployment steps in README

## Testing
- `mvn -f micro-services/*-service/pom.xml test` *(fails: Non-resolvable parent POM)*
- `terraform -chdir=terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883dbc504083289a09a91beff6eef7