### PR TITLE
Fix DB settings and disable unused JPA

### DIFF
--- a/helm-charts/billing-service/templates/deployment.yaml
+++ b/helm-charts/billing-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "billing-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/client-service/templates/deployment.yaml
+++ b/helm-charts/client-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "client-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/client-service/values.yaml
+++ b/helm-charts/client-service/values.yaml
@@ -16,11 +16,13 @@ resources:
 affinity: {}
 env:
   - name: SPRING_DATASOURCE_URL
-    value: jdbc:postgresql://postgresql-service:5432/client
+    value: jdbc:postgresql://postgresql-service:5432/clientdb
   - name: SPRING_DATASOURCE_USERNAME
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+  - name: SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA
+    value: client
 
 # Ingress configuration
 ingress:

--- a/helm-charts/gateway-service/templates/deployment.yaml
+++ b/helm-charts/gateway-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "gateway-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/matching-service/templates/deployment.yaml
+++ b/helm-charts/matching-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "matching-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/notification-service/templates/deployment.yaml
+++ b/helm-charts/notification-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "notification-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/provider-service/templates/deployment.yaml
+++ b/helm-charts/provider-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "provider-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/provider-service/values.yaml
+++ b/helm-charts/provider-service/values.yaml
@@ -16,11 +16,13 @@ resources:
 affinity: {}
 env:
   - name: SPRING_DATASOURCE_URL
-    value: jdbc:postgresql://postgresql-service:5432/provider
+    value: jdbc:postgresql://postgresql-service:5432/clientdb
   - name: SPRING_DATASOURCE_USERNAME
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+  - name: SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA
+    value: provider
 # Ingress configuration
 ingress:
   enabled: false

--- a/helm-charts/request-service/templates/deployment.yaml
+++ b/helm-charts/request-service/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: {{ include "request-service.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           resources:

--- a/helm-charts/request-service/values.yaml
+++ b/helm-charts/request-service/values.yaml
@@ -16,11 +16,13 @@ resources:
 affinity: {}
 env:
   - name: SPRING_DATASOURCE_URL
-    value: jdbc:postgresql://postgresql-service:5432/request
+    value: jdbc:postgresql://postgresql-service:5432/clientdb
   - name: SPRING_DATASOURCE_USERNAME
     value: admin
   - name: SPRING_DATASOURCE_PASSWORD
     value: admin
+  - name: SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA
+    value: request
 # Ingress configuration
 ingress:
   enabled: false

--- a/micro-services/billing-service/pom.xml
+++ b/micro-services/billing-service/pom.xml
@@ -30,17 +30,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- JPA -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <!-- PostgreSQL -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
 
         <!-- Kafka -->
         <dependency>

--- a/micro-services/billing-service/src/main/java/com/freelas/billing/BillingServiceApplication.java
+++ b/micro-services/billing-service/src/main/java/com/freelas/billing/BillingServiceApplication.java
@@ -2,8 +2,9 @@ package com.freelas.billing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class BillingServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(BillingServiceApplication.class, args);

--- a/micro-services/client-service/src/main/resources/application.yml
+++ b/micro-services/client-service/src/main/resources/application.yml
@@ -3,12 +3,14 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/client
+    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/clientdb
     username: admin
     password: admin
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate.default_schema: client
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 management:

--- a/micro-services/gateway-service/pom.xml
+++ b/micro-services/gateway-service/pom.xml
@@ -30,17 +30,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- JPA -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <!-- PostgreSQL -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
 
         <!-- Kafka -->
         <dependency>

--- a/micro-services/matching-service/pom.xml
+++ b/micro-services/matching-service/pom.xml
@@ -30,17 +30,6 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
 
-        <!-- JPA -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <!-- PostgreSQL -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
 
         <!-- Kafka -->
         <dependency>

--- a/micro-services/matching-service/src/main/java/com/freelas/matching/MatchingServiceApplication.java
+++ b/micro-services/matching-service/src/main/java/com/freelas/matching/MatchingServiceApplication.java
@@ -2,8 +2,9 @@ package com.freelas.matching;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class MatchingServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(MatchingServiceApplication.class, args);

--- a/micro-services/notification-service/pom.xml
+++ b/micro-services/notification-service/pom.xml
@@ -30,17 +30,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- JPA -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <!-- PostgreSQL -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
 
         <!-- Kafka -->
         <dependency>

--- a/micro-services/notification-service/src/main/java/com/freelas/notification/NotificationServiceApplication.java
+++ b/micro-services/notification-service/src/main/java/com/freelas/notification/NotificationServiceApplication.java
@@ -2,8 +2,9 @@ package com.freelas.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class NotificationServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(NotificationServiceApplication.class, args);

--- a/micro-services/provider-service/src/main/resources/application.yml
+++ b/micro-services/provider-service/src/main/resources/application.yml
@@ -3,12 +3,14 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/provider
+    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/clientdb
     username: admin
     password: admin
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate.default_schema: provider
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 

--- a/micro-services/request-service/src/main/resources/application.yaml
+++ b/micro-services/request-service/src/main/resources/application.yaml
@@ -3,12 +3,14 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/request
+    url: jdbc:postgresql://postgresql-service.freelas.svc.cluster.local:5432/clientdb
     username: admin
     password: admin
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate.default_schema: request
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 


### PR DESCRIPTION
## Summary
- remove unused JPA/PostgreSQL dependencies from services that do not persist data
- exclude `DataSourceAutoConfiguration` on services without a database
- fix datasource URLs to use the existing database and set schema
- allow Helm charts to pass env vars to deployments

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688847ebc0388328a4387e84b4f99a53