### PR TITLE
Enable docker networking for gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,35 @@ Ao final, confira os ingressos criados com:
 ```bash
 kubectl get ingress -n freelas-dev
 ```
+
+## Ambiente local com Docker Compose
+
+Para executar toda a stack em modo de desenvolvimento é fornecido um arquivo
+`docker-compose.yml` no diretório `micro-services`. Este compose cria uma
+instância do Kafka e um banco PostgreSQL dedicado para cada microserviço.
+
+Execute os serviços com:
+
+```bash
+cd micro-services
+docker compose up --build
+```
+
+Após o provisionamento os serviços podem ser acessados nas portas abaixo:
+
+| Serviço            | Porta |
+|--------------------|-------|
+| Gateway            | 8090  |
+| Provider           | 8081  |
+| Request            | 8082  |
+| Client             | 8083  |
+| Billing            | 8084  |
+| Notification       | 8099  |
+| Matching           | 8086  |
+
+O gateway já é configurado para se comunicar com os demais contêineres por meio
+dos nomes de serviço do Docker Compose. Caso queira alterar algum endereço,
+sobrescreva as variáveis de ambiente `PROVIDER_SERVICE_URL`,
+`REQUEST_SERVICE_URL`, `NOTIFICATION_SERVICE_URL`, `CLIENT_SERVICE_URL` ou
+`BILLING_SERVICE_URL` ao subir o `gateway-service`.
+

--- a/micro-services/gateway-service/src/main/resources/application.yml
+++ b/micro-services/gateway-service/src/main/resources/application.yml
@@ -13,27 +13,27 @@ spring:
     gateway:
       routes:
         - id: provider-service
-          uri: http://localhost:8081
+          uri: ${PROVIDER_SERVICE_URL:http://provider-service:8081}
           predicates:
             - Path=/providers/**
 
         - id: request-service
-          uri: http://localhost:8082
+          uri: ${REQUEST_SERVICE_URL:http://request-service:8082}
           predicates:
             - Path=/requests/**
 
         - id: notification-service
-          uri: http://localhost:8084
+          uri: ${NOTIFICATION_SERVICE_URL:http://notification-service:8084}
           predicates:
             - Path=/notifications/**
 
         - id: client-service
-          uri: http://localhost:8085
+          uri: ${CLIENT_SERVICE_URL:http://client-service:8085}
           predicates:
             - Path=/clients/**
 
         - id: billing-service
-          uri: http://localhost:8086
+          uri: ${BILLING_SERVICE_URL:http://billing-service:8086}
           predicates:
             - Path=/billing/**
 


### PR DESCRIPTION
## Summary
- allow overriding gateway routes via env vars so docker containers can talk to each other
- document local docker compose usage in README

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68885579e6308328890789bf801a6b7e